### PR TITLE
Add siteMetadata and fixing build errors

### DIFF
--- a/studio/schemas/documents/siteSettings.js
+++ b/studio/schemas/documents/siteSettings.js
@@ -5,25 +5,9 @@ export default {
   __experimental_actions: ['update', /* 'create', 'delete', */ 'publish'],
   fields: [
     {
-      name: 'title',
-      type: 'string',
-      title: 'Title'
-    },
-    {
-      name: 'description',
-      type: 'text',
-      title: 'Description',
-      description: 'Describe your blog for search engines and social media.'
-    },
-    {
-      name: 'keywords',
-      type: 'array',
-      title: 'Keywords',
-      description: 'Add keywords that describes your blog.',
-      of: [{type: 'string'}],
-      options: {
-        layout: 'tags'
-      }
+      name: 'siteMetadata',
+      type: 'siteMetadata',
+      title: 'Site Metadata'
     },
     {
       name: 'author',
@@ -32,5 +16,10 @@ export default {
       title: 'Author',
       to: [{type: 'author'}]
     }
-  ]
+  ],
+  preview: {
+    select: {
+      title: 'siteMetadata.title'
+    }
+  }
 }

--- a/studio/schemas/objects/siteMetadata.js
+++ b/studio/schemas/objects/siteMetadata.js
@@ -1,0 +1,33 @@
+export default {
+  name: 'siteMetadata',
+  title: 'Site Metadata',
+  type: 'object',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Site Title'
+    },
+    {
+      name: 'description',
+      type: 'text',
+      title: 'Description',
+      description: 'Describe your blog for search engines and social media.'
+    },
+    {
+      name: 'siteUrl',
+      type: 'url',
+      title: 'Site Url'
+    },
+    {
+      name: 'keywords',
+      type: 'array',
+      title: 'Keywords',
+      description: 'Add keywords that describes your blog.',
+      of: [{type: 'string'}],
+      options: {
+        layout: 'tags'
+      }
+    }
+  ]
+}

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -11,11 +11,12 @@ import post from './documents/post'
 import siteSettings from './documents/siteSettings'
 
 // Object types
-import bodyPortableText from './objects/bodyPortableText'
+import authorReference from './objects/authorReference'
 import bioPortableText from './objects/bioPortableText'
+import bodyPortableText from './objects/bodyPortableText'
 import excerptPortableText from './objects/excerptPortableText'
 import mainImage from './objects/mainImage'
-import authorReference from './objects/authorReference'
+import siteMetadata from './objects/siteMetadata'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -26,17 +27,17 @@ export default createSchema({
   types: schemaTypes.concat([
     // The following are document types which will appear
     // in the studio.
-    siteSettings,
-    post,
-    category,
     author,
-    mainImage,
-    authorReference,
-    bodyPortableText,
-    bioPortableText,
-    excerptPortableText
-
+    category,
+    post,
+    siteSettings,
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas
+    authorReference,
+    bioPortableText,
+    bodyPortableText,
+    excerptPortableText,
+    mainImage,
+    siteMetadata
   ])
 })

--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -33,15 +33,43 @@ module.exports = {
         start_url: `/`,
         background_color: `#f7f0eb`,
         theme_color: `#a2466c`,
-        display: `standalone`,
-        icon: `src/images/icon.png`
+        display: `standalone`
+        // icon: `src/images/icon.png`
       }
     },
     `gatsby-plugin-offline`,
-    `gatsby-plugin-sitemap`,
+    {
+      resolve: `gatsby-plugin-sitemap`,
+      options: {
+        query: `
+        {
+          site: sanitySiteSettings {
+            siteMetadata {
+              siteUrl
+            }
+          }
+
+          allSitePage {
+            edges {
+              node {
+                path
+              }
+            }
+          }
+        }`
+      }
+    },
     {
       resolve: `gatsby-plugin-robots-txt`,
       options: {
+        query: `
+        {
+          site: sanitySiteSettings {
+            siteMetadata {
+              siteUrl
+            }
+          }
+        }`,
         policy: [{userAgent: `*`, allow: `/`}]
       }
     },

--- a/web/src/components/seo.js
+++ b/web/src/components/seo.js
@@ -10,9 +10,9 @@ function SEO ({description, lang, meta, keywords, title, image, imageAlt, isPost
     <StaticQuery
       query={detailsQuery}
       render={data => {
-        const metaDescription = description || (data.site && data.site.description) || ''
-        const siteTitle = (data.site && data.site.title) || ''
-        const siteAuthor = (data.site && data.site.author && data.site.author.name) || ''
+        const metaDescription = description || (data.site && data.site.siteMetadata.description) || ''
+        const siteTitle = (data.site && data.site.siteMetadata.title) || ''
+        const siteAuthor = (data.site && data.site.siteMetadata.author && data.site.siteMetadata.author.name) || ''
         const metaImage = (image && image.asset) ? imageUrlFor(buildImageObj(image)).width(1200).url() : ''
 
         return (
@@ -119,9 +119,11 @@ export default SEO
 const detailsQuery = graphql`
   query DefaultSEOQuery {
     site: sanitySiteSettings(_id: {eq: "siteSettings"}) {
-      title
-      description
-      keywords
+      siteMetadata {
+        title
+        description
+        keywords
+      }
       author {
         name
       }

--- a/web/src/containers/layout.js
+++ b/web/src/containers/layout.js
@@ -5,7 +5,9 @@ import Layout from '../components/layout'
 const query = graphql`
   query SiteTitleQuery {
     site: sanitySiteSettings(_id: {regex: "/(drafts.|)siteSettings/"}) {
-      title
+      siteMetadata {
+        title
+      }
     }
   }
 `
@@ -31,7 +33,7 @@ function LayoutContainer (props) {
           <Layout
             {...props}
             showNav={showNav}
-            siteTitle={data.site.title}
+            siteTitle={data.site.siteMetadata.title}
             onHideNav={handleHideNav}
             onShowNav={handleShowNav}
           />

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -14,9 +14,11 @@ import Layout from '../containers/layout'
 export const query = graphql`
   query IndexPageQuery {
     site: sanitySiteSettings(_id: { regex: "/(drafts.|)siteSettings/" }) {
-      title
-      description
-      keywords
+      siteMetadata {
+        title
+        description
+        keywords
+      }
     }
     posts: allSanityPost(
       limit: 6
@@ -73,12 +75,12 @@ const IndexPage = props => {
   return (
     <Layout>
       <SEO
-        title={site.title}
-        description={site.description}
-        keywords={site.keywords}
+        title={site.siteMetadata.title}
+        description={site.siteMetadata.description}
+        keywords={site.siteMetadata.keywords}
       />
       <Container>
-        <h1 hidden>Welcome to {site.title}</h1>
+        <h1 hidden>Welcome to {site.siteMetadata.title}</h1>
         {postNodes && (
           <BlogPostPreviewList
             title='Latest blog posts'


### PR DESCRIPTION
# Overview

Fix build errors pertaining to `gatsby-config.js`.

## Details

* Add siteMetadata object in Sanity to query against for sitemap and robots plugins.
* Comment out the manifest icon (add on client by client basis)